### PR TITLE
feat: make the image numbers text size reponsive

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,21 +42,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -84,7 +77,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -150,21 +143,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   octo_image:
     dependency: transitive
     description:
@@ -178,7 +171,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -263,6 +256,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
+  responsive_sizer:
+    dependency: transitive
+    description:
+      name: responsive_sizer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
   rxdart:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   sqflite:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -330,14 +330,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/lib/galleryimage.dart
+++ b/lib/galleryimage.dart
@@ -1,6 +1,7 @@
 library galleryimage;
 
 import 'package:flutter/material.dart';
+import 'package:responsive_sizer/responsive_sizer.dart';
 
 import 'gallery_item_model.dart';
 import 'gallery_item_thumbnail.dart';
@@ -34,61 +35,69 @@ class _GalleryImageState extends State<GalleryImage> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-        padding: const EdgeInsets.all(10),
-        child: galleryItems.isEmpty
-            ? getEmptyWidget()
-            : GridView.builder(
-                primary: false,
-                itemCount: galleryItems.length > 3
-                    ? widget.numOfShowImages
-                    : galleryItems.length,
-                padding: const EdgeInsets.all(0),
-                semanticChildCount: 1,
-                gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
-                    crossAxisCount: 3, mainAxisSpacing: 0, crossAxisSpacing: 5),
-                shrinkWrap: true,
-                itemBuilder: (BuildContext context, int index) {
-                  return ClipRRect(
-                      borderRadius: const BorderRadius.all(Radius.circular(8)),
-                      // if have less than 4 image w build GalleryItemThumbnail
-                      // if have mor than 4 build image number 3 with number for other images
-                      child: index < galleryItems.length - 1 &&
-                              index == widget.numOfShowImages - 1
-                          ? buildImageNumbers(index)
-                          : GalleryItemThumbnail(
-                              galleryItem: galleryItems[index],
-                              onTap: () {
-                                openImageFullScreen(index);
-                              },
-                            ));
-                }));
+      padding: const EdgeInsets.all(10),
+      child: galleryItems.isEmpty
+          ? getEmptyWidget()
+          : GridView.builder(
+              primary: false,
+              itemCount: galleryItems.length > 3
+                  ? widget.numOfShowImages
+                  : galleryItems.length,
+              padding: const EdgeInsets.all(0),
+              semanticChildCount: 1,
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                  crossAxisCount: 3, mainAxisSpacing: 0, crossAxisSpacing: 5),
+              shrinkWrap: true,
+              itemBuilder: (BuildContext context, int index) {
+                return ClipRRect(
+                  borderRadius: const BorderRadius.all(Radius.circular(8)),
+                  // if have less than 4 image w build GalleryItemThumbnail
+                  // if have mor than 4 build image number 3 with number for other images
+                  child: index < galleryItems.length - 1 &&
+                          index == widget.numOfShowImages - 1
+                      ? buildImageNumbers(index)
+                      : GalleryItemThumbnail(
+                          galleryItem: galleryItems[index],
+                          onTap: () {
+                            openImageFullScreen(index);
+                          },
+                        ),
+                );
+              },
+            ),
+    );
   }
 
 // build image with number for other images
   Widget buildImageNumbers(int index) {
-    return GestureDetector(
-      onTap: () {
-        openImageFullScreen(index);
-      },
-      child: Stack(
-        alignment: AlignmentDirectional.center,
-        fit: StackFit.expand,
-        children: <Widget>[
-          GalleryItemThumbnail(
-            galleryItem: galleryItems[index],
-          ),
-          Container(
-            color: Colors.black.withOpacity(.7),
-            child: Center(
-              child: Text(
-                "+${galleryItems.length - index}",
-                style: const TextStyle(color: Colors.white, fontSize: 40),
+    return ResponsiveSizer(builder: (context, orientation, screenType) {
+      return GestureDetector(
+        onTap: () {
+          openImageFullScreen(index);
+        },
+        child: Stack(
+          alignment: AlignmentDirectional.center,
+          fit: StackFit.expand,
+          children: <Widget>[
+            GalleryItemThumbnail(
+              galleryItem: galleryItems[index],
+            ),
+            Container(
+              color: Colors.black.withOpacity(.7),
+              child: Center(
+                child: Text(
+                  "+${galleryItems.length - index}",
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 40.sp,
+                  ),
+                ),
               ),
             ),
-          ),
-        ],
-      ),
-    );
+          ],
+        ),
+      );
+    });
   }
 
 // to open gallery image in full screen

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -42,21 +42,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -77,7 +70,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -150,21 +143,21 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   octo_image:
     dependency: transitive
     description:
@@ -178,7 +171,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   path_provider:
     dependency: transitive
     description:
@@ -263,6 +256,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.4"
+  responsive_sizer:
+    dependency: "direct main"
+    description:
+      name: responsive_sizer
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.1"
   rxdart:
     dependency: transitive
     description:
@@ -281,7 +281,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
+    version: "1.9.0"
   sqflite:
     dependency: transitive
     description:
@@ -316,7 +316,7 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   synchronized:
     dependency: transitive
     description:
@@ -330,14 +330,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cached_network_image: ^3.2.1
   photo_view: ^0.14.0
+  responsive_sizer: ^3.1.1
 
 dev_dependencies:
   flutter_lints: ^2.0.1


### PR DESCRIPTION
In the current version, the image numbers text size doesn't adapt to device size, for exemple with a very small device can only see a single one digit if the numbers exced 2 digits and this commit contain a fix using the package responsive_sizer