### PR TITLE
Fix bugs in (bottom) image list rendering and allow tracking of the current image.

### DIFF
--- a/lib/gallery_image_view_wrapper.dart
+++ b/lib/gallery_image_view_wrapper.dart
@@ -7,6 +7,7 @@ import 'gallery_item_model.dart';
 class GalleryImageViewWrapper extends StatefulWidget {
   final Color? backgroundColor;
   final int? initialIndex;
+  final void Function(int)? onPageChanged;
   final List<GalleryItemModel> galleryItems;
   final String? titleGallery;
   final Widget? loadingWidget;
@@ -25,6 +26,7 @@ class GalleryImageViewWrapper extends StatefulWidget {
     required this.titleGallery,
     required this.backgroundColor,
     required this.initialIndex,
+    required this.onPageChanged,
     required this.galleryItems,
     required this.loadingWidget,
     required this.errorWidget,
@@ -51,12 +53,8 @@ class _GalleryImageViewWrapperState extends State<GalleryImageViewWrapper> {
 
   @override
   void initState() {
-    _currentPage = 0;
-    _controller.addListener(() {
-      setState(() {
-        _currentPage = _controller.page?.toInt() ?? 0;
-      });
-    });
+    _currentPage = widget.initialIndex ?? 0;
+    widget.onPageChanged?.call(_currentPage);
     super.initState();
   }
 
@@ -101,6 +99,12 @@ class _GalleryImageViewWrapperState extends State<GalleryImageViewWrapper> {
                     itemCount: widget.galleryItems.length,
                     itemBuilder: (context, index) =>
                         _buildImage(widget.galleryItems[index]),
+                    onPageChanged: (index) {
+                      widget.onPageChanged?.call(index);
+                      setState(() {
+                        _currentPage = index;
+                      });
+                    },
                   ),
                 ),
               ),

--- a/lib/galleryimage.dart
+++ b/lib/galleryimage.dart
@@ -9,6 +9,7 @@ import './util.dart';
 
 class GalleryImage extends StatefulWidget {
   final List<String> imageUrls;
+  final void Function(int)? onPageChanged;
   final String? titleGallery;
   final int numOfShowImages;
   final int crossAxisCount;
@@ -33,6 +34,7 @@ class GalleryImage extends StatefulWidget {
   const GalleryImage({
     Key? key,
     required this.imageUrls,
+    this.onPageChanged,
     this.titleGallery,
     this.childAspectRatio = 1,
     this.crossAxisCount = 3,
@@ -150,6 +152,7 @@ class _GalleryImageState extends State<GalleryImage> {
           galleryItems: galleryItems,
           backgroundColor: widget.galleryBackgroundColor,
           initialIndex: indexOfImage,
+          onPageChanged: widget.onPageChanged,
           loadingWidget: widget.loadingWidget,
           errorWidget: widget.errorWidget,
           maxScale: widget.maxScale,


### PR DESCRIPTION
This pull request addresses two bugs and adds one feature:

1. When the user taps on any images after the first image to open the gallery, the bottom image list will zoom in to the incorrect image as `_currentPage` is initialized to `0` instead of `widget.initialIndex`.
2. The bottom image list does not update immediately when the user performs a left or right swipe gesture to change the image. To address this issue, the `onPageChanged` callback of the `PageView` is used instead of adding a listener to the `PageController`.
3. The `onPageChanged` callback is added to allow the parent widget to be informed of the current visible image in the gallery. This functionality is needed for use with a custom AppBar action button (see #18) to implement some actions based on the current image, e.g., download or delete.